### PR TITLE
Add support for functions, arbitrary tag names and exporting all types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/olahol/tsreflect
+module github.com/ortfo/tsreflect
 
 go 1.20

--- a/tsreflect.go
+++ b/tsreflect.go
@@ -78,6 +78,7 @@ type Generator struct {
 	warnings bool
 	warn     func(string, ...any)
 	namer    Namer
+	export   bool
 
 	typers   map[reflect.Type]Typer
 	types    map[reflect.Type]struct{}
@@ -121,6 +122,13 @@ func WithNoWarnings() Option {
 func WithTyper(typ reflect.Type, typer Typer) Option {
 	return func(g *Generator) {
 		g.typers[typ] = typer
+	}
+}
+
+// ExportEverything adds an option that makes export all generated types
+func ExportEverything() Option {
+	return func(g *Generator) {
+		g.export = true
 	}
 }
 
@@ -396,6 +404,9 @@ func (g *Generator) declarations(jsDoc bool) string {
 		if jsDoc {
 			sb.WriteString("/** @typedef {")
 		} else {
+			if g.export {
+				sb.WriteString("export ")
+			}
 			if decl.IsFunction {
 				if g.async[decl.Name] {
 					sb.WriteString("async ")

--- a/tsreflect.go
+++ b/tsreflect.go
@@ -185,7 +185,6 @@ func (g *Generator) AddFunc(typ reflect.Type, name string, async bool, implement
 	} else if len(implementation) == 1 {
 		impl = implementation[0]
 	}
-	println("adding function ", name)
 	g.add(typ, nil, name, async, impl)
 }
 

--- a/tsreflect.go
+++ b/tsreflect.go
@@ -510,8 +510,16 @@ func (g *Generator) writeStructFields(sb *strings.Builder, typ reflect.Type) {
 }
 
 func hasTagOmit(f reflect.StructField) bool {
-	if tag, ok := f.Tag.Lookup("json"); ok && tag == "-" {
+	jsonTagFound := false
+	var tag string
+	if tag, jsonTagFound = f.Tag.Lookup("json"); jsonTagFound && tag == "-" {
 		return true
+	}
+
+	if !jsonTagFound {
+		if tag, ok := f.Tag.Lookup("yaml"); ok && tag == "-" {
+			return true
+		}
 	}
 
 	return false
@@ -522,7 +530,17 @@ func (g *Generator) structField(f reflect.StructField) string {
 	omit := false
 
 	var typ string
-	if tag, ok := f.Tag.Lookup("json"); ok {
+	var tag string
+
+	if jsonTag, ok := f.Tag.Lookup("json"); ok {
+		tag = jsonTag
+	}
+
+	if yamlTag, ok := f.Tag.Lookup("yaml"); ok && tag == "" {
+		tag = yamlTag
+	}
+
+	if tag != "" {
 		if !strings.ContainsRune(tag, ',') {
 			name = tag
 		} else {


### PR DESCRIPTION
Hi! I'm using this package to automatically generate types of bound functions in a [webview](https://pkg.go.dev/github.com/webview/webview) desktop app.

Essentially, the webview allows exposing to frontend (JS) code functions that run on the Go backend.

With this package, the frontend code can very easily have typedefinitions for the bound functions with zero effort.

Obviously, since I need to use this patch right now (and vendoring packages seems complicated when using go workspaces), this PR contains a change that renames the module

```diff
--- a/go.mod
+++ b/go.mod
@@ -1,2 +1,2 @@
-module github.com/olahol/tsreflect
+module github.com/ortfo/tsreflect
```

... i'll remove it before merging (if you want to merge this) ^^

Thanks a bunch for this package! It's a real time saver! :D


This PR adds three things:

- support for adding functions with `(*tsreflect.Generator).AddFunc(typ, name, async, implementation?)` where:
  -  `name` is the function's name (since it's not stored in `typ`)
  -  `async` can be set to `true` to mark the function as asynchronous (this generates `async function name(...): Promise<...>` instead of `function name(...): ...`
  - `implementation` (optional argument) is a string with source code, useful when the implementation is easy, like in my use case. Adds a body to the function: `export function ... { ... }` instead of `export function ...`
- a new option to export all types and functions by adding the `export` keyword before `interface` / `function`: `tsreflect.ExportEverything`
- allowing tags other than `json` to take precedence when naming struct fields: in my use case, I have also `yaml` tags on some structs since they are (un)marshaled from and to YAML files. sometimes there are both YAML and JSON tags, when they differ, sometimes not. For now YAML is hardcoded but I plan to make another option: `tsreflect.UseTags(names... string)` that takes tag names, in their order of priority (last elements are used as fallback when the elements before are not tag names on the structs' fields)

Note that error values in the return types are handled correctly, they are elided from the generated code, since they should, in their typescript implementation, be translated into `throw`s

Note also: I haven't done the jsdoc part yet, but I suppose errors could be added there as a `@throws`, but appart from adding `@throws {Error}` i can't see where we would get more specific info

TODO:

- [ ] JSDoc generation
- [ ] Documentation of all functions
- [ ] Implementation of `WithStructTags`